### PR TITLE
Message Handler Fix: Not Invoking Beans

### DIFF
--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/message/CbMessageListenerProcessor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/message/CbMessageListenerProcessor.java
@@ -24,7 +24,7 @@ public class CbMessageListenerProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        handler.processClass(bean);
+        handler.processBean(bean);
         return bean;
     }
 

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/SbMessageListenerProcessor.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/SbMessageListenerProcessor.java
@@ -25,7 +25,7 @@ public class SbMessageListenerProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        handler.processClass(bean);
+        handler.processBean(bean);
         return bean;
     }
 

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/message/MessageHandler.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/message/MessageHandler.java
@@ -94,11 +94,11 @@ public class MessageHandler<MessageType, PayloadCaseType extends Enum<?>, Annota
         }
     }
 
-    public void processClass(Object clazz) {
-        for (Method method : clazz.getClass().getMethods()) {
+    public void processBean(Object bean) {
+        for (Method method : bean.getClass().getMethods()) {
             if (method.isAnnotationPresent(annotationClass)) {
                 try {
-                    registerListener(method);
+                    registerListener(bean, method);
                     logger.debug("Registered {} for message {} on method {}#{}",
                             messageClass.getName(),
                             method.getParameters()[0].getType().getName(),
@@ -115,7 +115,7 @@ public class MessageHandler<MessageType, PayloadCaseType extends Enum<?>, Annota
         }
     }
 
-    private void registerListener(Method method) {
+    private void registerListener(Object bean, Method method) {
         if (method.getParameterCount() == 2
                 && method.getParameters()[1].getType() == UUID.class) {
             Class<?> messageType = method.getParameters()[0].getType();
@@ -127,8 +127,14 @@ public class MessageHandler<MessageType, PayloadCaseType extends Enum<?>, Annota
 
             registerExecutor(messageType, (message, client) -> {
                 try {
+<<<<<<< Updated upstream
                     method.invoke(message, client);
                 } catch (IllegalAccessException | InvocationTargetException exception) {
+=======
+                    logger.info("DEBUG: " + message.getClass().getName()+" method "+method.getName());
+                    method.invoke(bean, message, client);
+                } catch (Exception exception) {
+>>>>>>> Stashed changes
                     throw new RuntimeException(exception);
                 }
             });

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/message/MessageHandler.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/message/MessageHandler.java
@@ -127,7 +127,7 @@ public class MessageHandler<MessageType, PayloadCaseType extends Enum<?>, Annota
 
             registerExecutor(messageType, (message, client) -> {
                 try {
-                    method.invoke(message, client);
+                    method.invoke(bean, message, client);
                 } catch (Exception exception) {
                     throw new RuntimeException(exception);
                 }

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/message/MessageHandler.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/message/MessageHandler.java
@@ -127,14 +127,8 @@ public class MessageHandler<MessageType, PayloadCaseType extends Enum<?>, Annota
 
             registerExecutor(messageType, (message, client) -> {
                 try {
-<<<<<<< Updated upstream
                     method.invoke(message, client);
-                } catch (IllegalAccessException | InvocationTargetException exception) {
-=======
-                    logger.info("DEBUG: " + message.getClass().getName()+" method "+method.getName());
-                    method.invoke(bean, message, client);
                 } catch (Exception exception) {
->>>>>>> Stashed changes
                     throw new RuntimeException(exception);
                 }
             });


### PR DESCRIPTION
- Fixed a bug where when trying to execute messages annotated with `@CbMessageListener` or `@SbMessageListener` when receiving the corresponding packet, this would fail because we weren't passing the parent bean into the method invocation.
