### PR TITLE
New Session Open/Close Flow

### DIFF
--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/GameLogic.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/GameLogic.java
@@ -33,7 +33,7 @@ public class GameLogic {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-        
+
         // Move to the main game screen after the welcome screen
         frame.getContentPane().removeAll(); // Clear welcome screen components
         JLabel gameLabel = new JLabel("Game is running...");

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketHandler.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketHandler.java
@@ -42,13 +42,14 @@ public class ClientSocketHandler extends BinaryWebSocketHandler {
     @Autowired
     private ApplicationEventPublisher eventPublisher;
 
-    public void open(String address, int port, UUID clientId) {
+    public void open(String address, int port, UUID clientId, String playerName) {
         if (isOpen()) {
             throw new IllegalStateException("Cannot open client socket when it is already open!");
         }
         this.clientId = clientId;
         WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
         headers.add(SharedConstants.CLIENT_ID_HTTP_HEADER, clientId.toString());
+        headers.add(SharedConstants.CLIENT_NAME_HTTP_HEADER, playerName);
         try {
             URI uri = new URI("ws://" + address + ":" + port + SharedConstants.GAME_SOCKET_ENDPOINT);
             session = client.execute(this, headers, uri).get();

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/GameSocketHandler.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/GameSocketHandler.java
@@ -83,17 +83,27 @@ public class GameSocketHandler extends BinaryWebSocketHandler {
 
 
     public void sendCbMessage(UUID clientId, CbMessage message) {
+        ClientSession targetSession = getSessionFromClientId(clientId);
+        if (targetSession == null) {
+            throw new IllegalArgumentException("Cannot send message to invalid client " + clientId);
+        }
+        sendCbMessage(targetSession, message);
+    }
+
+    public void sendCbMessage(ClientSession targetSession, CbMessage message) {
         try {
-            ClientSession targetSession = getSessionFromClientId(clientId);
-            if (targetSession == null) {
-                throw new IllegalArgumentException("Cannot send message to invalid client " + clientId);
-            }
             WebSocketSession session = sessions.get(targetSession);
             byte[] messageBytes = message.toByteArray();
             session.sendMessage(new BinaryMessage(messageBytes));
-            logger.debug("Sending client {} message of type {}", clientId.toString(), message.getPayloadCase().name());
+            logger.debug("Sending client {} message of type {}", targetSession.getClientId().toString(), message.getPayloadCase().name());
         } catch (IOException exception) {
-            throw new RuntimeException("Failed to send client " + clientId.toString() + " packet of type " + message.getPayloadCase().name(), exception);
+            throw new RuntimeException("Failed to send client " + targetSession.getClientId().toString() + " packet of type " + message.getPayloadCase().name(), exception);
+        }
+    }
+
+    public void broadcastCbMessage(CbMessage message) {
+        for (ClientSession session : this.getSessions()) {
+            this.sendCbMessage(session, message);
         }
     }
 

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/GameSocketHandler.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/GameSocketHandler.java
@@ -8,8 +8,6 @@ import dev.totallyspies.spydle.shared.SharedConstants;
 import dev.totallyspies.spydle.shared.model.ClientSession;
 import dev.totallyspies.spydle.shared.proto.messages.CbMessage;
 import dev.totallyspies.spydle.shared.proto.messages.SbMessage;
-import java.util.Collection;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,10 +20,12 @@ import org.springframework.web.socket.handler.BinaryWebSocketHandler;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class GameSocketHandler extends BinaryWebSocketHandler {
@@ -44,10 +44,10 @@ public class GameSocketHandler extends BinaryWebSocketHandler {
     @Autowired
     private ApplicationEventPublisher publisher;
 
-    private final Map<ClientSession, WebSocketSession> sessions = new ConcurrentHashMap<>();
-
-    public Collection<ClientSession> getSessions() {
-        return sessions.keySet();
+    private final Map<ClientSession, WebSocketSession> sessions = Collections.synchronizedMap(new LinkedHashMap<>());
+    
+    public List<ClientSession> getSessions() {
+        return new LinkedList<>(sessions.keySet());
     }
 
     @Override

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/GameSocketHandler.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/GameSocketHandler.java
@@ -1,8 +1,11 @@
 package dev.totallyspies.spydle.gameserver.message;
 
-import dev.totallyspies.spydle.gameserver.session.ClientSessionValidator;
+import dev.totallyspies.spydle.gameserver.message.session.ClientSessionValidator;
+import dev.totallyspies.spydle.gameserver.message.session.SessionCloseEvent;
+import dev.totallyspies.spydle.gameserver.message.session.SessionOpenEvent;
 import dev.totallyspies.spydle.gameserver.storage.GameServerStorage;
 import dev.totallyspies.spydle.shared.SharedConstants;
+import dev.totallyspies.spydle.shared.model.ClientSession;
 import dev.totallyspies.spydle.shared.proto.messages.CbMessage;
 import dev.totallyspies.spydle.shared.proto.messages.SbMessage;
 import java.util.Collection;
@@ -10,6 +13,7 @@ import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
@@ -26,8 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class GameSocketHandler extends BinaryWebSocketHandler {
 
-    private static final String HEADER = SharedConstants.CLIENT_ID_HTTP_HEADER;
-
     private final Logger logger = LoggerFactory.getLogger(GameSocketHandler.class);
 
     @Autowired
@@ -39,26 +41,35 @@ public class GameSocketHandler extends BinaryWebSocketHandler {
     @Autowired
     private SbMessageListenerProcessor annotationProcessor;
 
-    private final Map<UUID, WebSocketSession> sessions = new ConcurrentHashMap<>();
+    @Autowired
+    private ApplicationEventPublisher publisher;
 
-    public Collection<UUID> getSessions() {
+    private final Map<ClientSession, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+    public Collection<ClientSession> getSessions() {
         return sessions.keySet();
     }
 
     @Override
-    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) throws IOException {
-        String rawClientId = getClientId(session);
+    protected void handleBinaryMessage(WebSocketSession socketSession, BinaryMessage message) throws IOException {
+        String rawClientId = getHeader(socketSession, SharedConstants.CLIENT_ID_HTTP_HEADER);
         UUID clientId = sessionValidator.parseClientId(rawClientId);
         // Validate session has clientId
         if (clientId == null) {
-            logger.warn("Received packet on session {} without header {}", rawClientId, HEADER);
+            logger.warn("Received message on session {} without header {}", rawClientId, SharedConstants.CLIENT_ID_HTTP_HEADER);
+            return;
+        }
+
+        String clientName = getHeader(socketSession, SharedConstants.CLIENT_NAME_HTTP_HEADER);
+        if (clientName == null) {
+            logger.warn("Received message on session {} without header {}", rawClientId, SharedConstants.CLIENT_NAME_HTTP_HEADER);
             return;
         }
 
         // Validate that session is allowed to communicate with this gameserver
-        if (!sessionValidator.validateClientSession(clientId)) {
-            session.close(CloseStatus.NOT_ACCEPTABLE);
-            logger.warn("Received packet from unconfirmed session {}", rawClientId);
+        if (!sessionValidator.validateClientSession(clientId, clientName)) {
+            socketSession.close(CloseStatus.NOT_ACCEPTABLE);
+            logger.warn("Received message from unconfirmed session {}", rawClientId);
             return;
         }
 
@@ -73,10 +84,11 @@ public class GameSocketHandler extends BinaryWebSocketHandler {
 
     public void sendCbMessage(UUID clientId, CbMessage message) {
         try {
-            WebSocketSession session = sessions.get(clientId);
-            if (session == null) {
-                throw new IllegalArgumentException("Cannot send message to invalid client " + clientId.toString());
+            ClientSession targetSession = getSessionFromClientId(clientId);
+            if (targetSession == null) {
+                throw new IllegalArgumentException("Cannot send message to invalid client " + clientId);
             }
+            WebSocketSession session = sessions.get(targetSession);
             byte[] messageBytes = message.toByteArray();
             session.sendMessage(new BinaryMessage(messageBytes));
             logger.debug("Sending client {} message of type {}", clientId.toString(), message.getPayloadCase().name());
@@ -86,40 +98,90 @@ public class GameSocketHandler extends BinaryWebSocketHandler {
     }
 
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    public void afterConnectionEstablished(WebSocketSession socketSession) throws Exception {
         // Validate that the client has been assigned to us
-        String rawClientId = getClientId(session);
+        String rawClientId = getHeader(socketSession, SharedConstants.CLIENT_ID_HTTP_HEADER);
         UUID clientId = sessionValidator.parseClientId(rawClientId);
-        if (clientId == null || !sessionValidator.validateClientSession(clientId)) {
-            session.close(CloseStatus.NOT_ACCEPTABLE);
+        String clientName = getHeader(socketSession, SharedConstants.CLIENT_NAME_HTTP_HEADER);
+        if (clientName == null) {
+            socketSession.close(CloseStatus.NOT_ACCEPTABLE);
+            logger.warn("Client attempted to open session {} with no name, closing...", rawClientId);
+            return;
+        }
+        if (clientId == null || !sessionValidator.validateClientSession(clientId, clientName)) {
+            socketSession.close(CloseStatus.NOT_ACCEPTABLE);
             logger.warn("Client attempted to open unconfirmed session {}, closing...", rawClientId);
             return;
         }
-        sessions.put(clientId, session);
-        logger.info("Initiated connection with client {}", clientId);
+        if (hasSessionWithPlayerName(clientName)) {
+            socketSession.close(CloseStatus.NOT_ACCEPTABLE); // TODO: have some way to notify the player that their name is taken already
+            logger.warn("Client attempted to open session {} but their name already exists, closing...", rawClientId);
+            return;
+        }
+        ClientSession storedSession = storage.getClientSession(clientId);
+        if (storedSession == null) {
+            socketSession.close(CloseStatus.NOT_ACCEPTABLE);
+            logger.warn("Client attempted to open session {} with no stored client session for this UUID, closing...", rawClientId);
+            return;
+        }
+        sessions.put(storedSession, socketSession);
+        logger.info("Initiated connection with client {} and name {}", clientId, clientName);
+        publisher.publishEvent(new SessionOpenEvent(this, storedSession, socketSession));
     }
 
     @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        // Validate that the client had a connection with us before deleting the session
-        String rawClientId = getClientId(session);
+    public void afterConnectionClosed(WebSocketSession socketSession, CloseStatus status) {
+        // Validate that the client had a connection with us before deleting the socketSession
+        String rawClientId = getHeader(socketSession, SharedConstants.CLIENT_ID_HTTP_HEADER);
         UUID clientId = sessionValidator.parseClientId(rawClientId);
-        if (clientId != null && sessionValidator.validateClientSession(clientId)) {
-            storage.deleteClientSession(clientId);
+        String clientName = getHeader(socketSession, SharedConstants.CLIENT_NAME_HTTP_HEADER);
+        if (clientName == null) {
+            logger.warn("Client {} closed with no name", clientId);
+        } else {
+            if (clientId != null && sessionValidator.validateClientSession(clientId, clientName)) {
+                storage.deleteClientSession(clientId);
+            }
         }
+
         if (clientId != null) {
-            sessions.remove(clientId);
+            ClientSession session = getSessionFromClientId(clientId);
+            if (session != null) {
+                try {
+                    sessions.remove(session).close();
+                } catch (IOException exception) {
+                    logger.error("Failed to close session {}", clientId, exception);
+                }
+                publisher.publishEvent(new SessionCloseEvent(this, session, socketSession));
+            }
         }
         logger.info("Closed connection with client {} for reason {}", rawClientId, status);
     }
 
     @Nullable
-    private static String getClientId(WebSocketSession session) {
-        List<String> headerValues = session.getHandshakeHeaders().get(HEADER);
+    private static String getHeader(WebSocketSession session, String headerName) {
+        List<String> headerValues = session.getHandshakeHeaders().get(headerName);
         if (headerValues == null || headerValues.isEmpty()) {
             return null;
         }
         return headerValues.get(0);
     }
+
+    @Nullable
+    public ClientSession getSessionFromClientId(UUID clientId) {
+        return sessions
+                .keySet()
+                .stream()
+                .filter(session -> session.getClientId().equals(clientId))
+                .findAny()
+                .orElse(null);
+    }
+
+    private boolean hasSessionWithPlayerName(String name) {
+        return sessions
+                .keySet()
+                .stream()
+                .anyMatch(session -> session.getPlayerName().equalsIgnoreCase(name));
+    }
+
 
 }

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/ClientSessionValidator.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/ClientSessionValidator.java
@@ -1,11 +1,13 @@
-package dev.totallyspies.spydle.gameserver.session;
+package dev.totallyspies.spydle.gameserver.message.session;
+
+import dev.totallyspies.spydle.shared.model.ClientSession;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
 
 public interface ClientSessionValidator {
 
-    boolean validateClientSession(UUID clientId);
+    boolean validateClientSession(UUID clientId, String name);
 
     @Nullable
     default UUID parseClientId(Object clientIdObject) {

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/IntegratedClientSessionValidator.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/IntegratedClientSessionValidator.java
@@ -1,4 +1,4 @@
-package dev.totallyspies.spydle.gameserver.session;
+package dev.totallyspies.spydle.gameserver.message.session;
 
 import dev.totallyspies.spydle.gameserver.storage.GameServerStorage;
 import dev.totallyspies.spydle.shared.model.ClientSession;
@@ -30,7 +30,7 @@ public class IntegratedClientSessionValidator implements ClientSessionValidator 
     }
 
     @Override
-    public boolean validateClientSession(UUID clientId) {
+    public boolean validateClientSession(UUID clientId, String name) {
         Object rawSession = storage.getClientSession(clientId);
         if (!(rawSession instanceof ClientSession session)) return false;
         return currentGameServer.equals(session.getGameServer());

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/LocalClientSessionValidator.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/LocalClientSessionValidator.java
@@ -1,4 +1,4 @@
-package dev.totallyspies.spydle.gameserver.session;
+package dev.totallyspies.spydle.gameserver.message.session;
 
 import dev.totallyspies.spydle.gameserver.storage.GameServerStorage;
 import dev.totallyspies.spydle.shared.model.ClientSession;
@@ -28,8 +28,8 @@ public class LocalClientSessionValidator implements ClientSessionValidator {
     }
 
     @Override
-    public boolean validateClientSession(UUID clientId) {
-        storage.storeClientSession(new ClientSession(clientId, currentGameServer));
+    public boolean validateClientSession(UUID clientId, String name) {
+        storage.storeClientSession(new ClientSession(clientId, currentGameServer, name));
         return true;
     }
 

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/SessionCloseEvent.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/SessionCloseEvent.java
@@ -1,0 +1,21 @@
+package dev.totallyspies.spydle.gameserver.message.session;
+
+import dev.totallyspies.spydle.shared.model.ClientSession;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.web.socket.WebSocketSession;
+
+// Fired AFTER socket closed
+@Getter
+public class SessionCloseEvent extends ApplicationEvent {
+
+    private final ClientSession session;
+    private final WebSocketSession socketSession;
+
+    public SessionCloseEvent(Object source, ClientSession session, WebSocketSession socketSession) {
+        super(source);
+        this.session = session;
+        this.socketSession = socketSession;
+    }
+
+}

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/SessionOpenEvent.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/message/session/SessionOpenEvent.java
@@ -1,0 +1,21 @@
+package dev.totallyspies.spydle.gameserver.message.session;
+
+import dev.totallyspies.spydle.shared.model.ClientSession;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.web.socket.WebSocketSession;
+
+// Fired AFTER socket open
+@Getter
+public class SessionOpenEvent extends ApplicationEvent {
+
+    private final ClientSession session;
+    private final WebSocketSession socketSession;
+
+    public SessionOpenEvent(Object source, ClientSession session, WebSocketSession socketSession) {
+        super(source);
+        this.session = session;
+        this.socketSession = socketSession;
+    }
+
+}

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/storage/GameShutdownHook.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/storage/GameShutdownHook.java
@@ -1,6 +1,7 @@
 package dev.totallyspies.spydle.gameserver.storage;
 
 import dev.totallyspies.spydle.gameserver.message.GameSocketHandler;
+import dev.totallyspies.spydle.shared.model.ClientSession;
 import dev.totallyspies.spydle.shared.model.GameServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +38,8 @@ public class GameShutdownHook implements ApplicationListener<ApplicationReadyEve
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             logger.info("Executing custom shutdown hook, clearing redis data");
             storage.deleteGameServer(currentGameServer);
-            for (UUID clientId : handler.getSessions()) {
-                storage.deleteClientSession(clientId);
+            for (ClientSession session : handler.getSessions()) {
+                storage.deleteClientSession(session);
             }
         }));
     }

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/controller/GameController.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/controller/GameController.java
@@ -51,9 +51,12 @@ public class GameController {
             return ResponseEntity.status(400).body(new ClientErrorResponse().message("Bad clientId: should be UUID"));
         }
         try {
-            GameServer gameServer = matchmakingService.createGame(clientId);
+            GameServer gameServer = matchmakingService.createGame(clientId, request.getPlayerName());
             logger.info("Successfully handled /create-game request: {}", gameServer);
-            return ResponseEntity.ok(new CreateGameResponseModel().gameServer(gameServer));
+            return ResponseEntity.ok(new CreateGameResponseModel()
+                    .gameServer(gameServer)
+                    .clientId(request.getClientId())
+                    .playerName(request.getPlayerName()));
         } catch (Exception exception) {
             logger.error("Failed to handle /create-game", exception);
             return ResponseEntity.status(500).body(exception.getMessage());
@@ -82,9 +85,12 @@ public class GameController {
                         new ClientErrorResponse().message("Cannot join room: you are already in one"));
             }
             GameServer gameServer = gameServerRepository.getGameServer(request.getRoomCode());
-            matchmakingService.joinGame(clientId, gameServer);
+            matchmakingService.joinGame(clientId, request.getPlayerName(), gameServer);
             logger.info("Successfully handled /join-game request: {}", gameServer);
-            return ResponseEntity.ok(new JoinGameResponseModel().gameServer(gameServer));
+            return ResponseEntity.ok(new JoinGameResponseModel()
+                    .gameServer(gameServer)
+                    .clientId(request.getClientId())
+                    .playerName(request.getPlayerName()));
         } catch (Exception exception) {
             logger.error("Failed to handle /join-game", exception);
             return ResponseEntity.status(500).body(exception.getMessage());

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/service/MatchmakingService.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/service/MatchmakingService.java
@@ -24,26 +24,26 @@ public class MatchmakingService {
     @Autowired
     private GameServerRepository gameServerRepository;
 
-    public GameServer createGame(UUID clientId) {
+    public GameServer createGame(UUID clientId, String playerName) {
         // Check if client already has a session
         if (sessionRepository.sessionExists(clientId)) throw new IllegalStateException("Client is already in a game.");
 
         GameServer allocated = allocator.awaitAllocation();
 
         // Save client session
-        ClientSession session = new ClientSession(clientId, allocated);
+        ClientSession session = new ClientSession(clientId, allocated, playerName);
         sessionRepository.saveSession(session);
 
         return allocated;
     }
 
-    public void joinGame(UUID clientId, GameServer room) {
+    public void joinGame(UUID clientId, String playerName, GameServer room) {
         // Check if client already has a session
         if (sessionRepository.sessionExists(clientId)) {
             throw new IllegalStateException("Client is already in a game.");
         }
         // Save client session
-        ClientSession session = new ClientSession(clientId, room);
+        ClientSession session = new ClientSession(clientId, room, playerName);
         sessionRepository.saveSession(session);
     }
 

--- a/matchmaker/src/main/resources/openapi.yaml
+++ b/matchmaker/src/main/resources/openapi.yaml
@@ -143,30 +143,42 @@ components:
               type: string
     CreateGameRequestModel:
       type: object
-      required: [clientId]
+      required: [clientId, playerName]
       properties:
         clientId:
           type: string
+        playerName:
+          type: string
     CreateGameResponseModel:
       type: object
-      required: [gameServer]
+      required: [gameServer, clientId, playerName]
       properties:
         gameServer:
           $ref: '#/components/schemas/GameServer'
+        clientId:
+          type: string
+        playerName:
+          type: string
     JoinGameRequestModel:
       type: object
-      required: [clientId]
+      required: [clientId, playerName, roomCode]
       properties:
         clientId:
+          type: string
+        playerName:
           type: string
         roomCode:
           type: string
     JoinGameResponseModel:
       type: object
-      required: [gameServer]
+      required: [gameServer, clientId, playerName]
       properties:
         gameServer:
           $ref: '#/components/schemas/GameServer'
+        clientId:
+          type: string
+        playerName:
+          type: string
     ListGamesResponseModel:
       type: object
       required: [roomCodes]

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/SharedConstants.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/SharedConstants.java
@@ -4,6 +4,7 @@ public class SharedConstants {
 
     public static final String GAME_SOCKET_ENDPOINT = "/game";
     public static final String CLIENT_ID_HTTP_HEADER = "X-Client-ID";
+    public static final String CLIENT_NAME_HTTP_HEADER = "X-Client-Name";
 
     public static final String STORAGE_REDIS_SESSION_PREFIX = "session:";
     public static final String STORAGE_REDIS_GAME_SERVER_PREFIX = "gameserver:";

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/model/ClientSession.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/model/ClientSession.java
@@ -15,6 +15,7 @@ public class ClientSession implements Serializable {
 
     private UUID clientId;
     private GameServer gameServer;
+    private String playerName;
 
     public static void validateJsonElement(JsonElement clientSession) {
         JsonValidator.validateJsonElement(clientSession, ClientSession.class);

--- a/shared/src/main/proto/game.proto
+++ b/shared/src/main/proto/game.proto
@@ -5,18 +5,13 @@ option java_multiple_files = true;
 
 message SbMessage {
   oneof payload {
-    SbJoinGame join_game = 1;
-    SbStartGame start_game = 2;
-    SbLeaveGame leave_game = 3;
-    SbGuess guess = 4;
+    SbStartGame start_game = 1;
+    SbLeaveGame leave_game = 2;
+    SbGuess guess = 3;
   }
 }
 
 // Server-bound messages
-message SbJoinGame {
-  string player_name = 1;
-}
-
 message SbStartGame {
 }
 


### PR DESCRIPTION
## Changes
- Removed SbJoinGame (previously known as SbSelectName) message
  - Instead, when clients open a websocket, they are required to pass in a playerName as an HTTP header (`X-Client-Name`)
    - This can be rejected if we already have a client with the same name
      - Currently there is no logic for explaining to the client why this rejected occurred (its just a generic error)
    - Players are also required to add this playerName when they send a `/create-game` or `/join-game` request to the matchmaker
      - This is because we need to store their sessions with their player names with the matchmaker
- Matchmaker forwards the clientId and playerName that was used for its `/create-game` or `/join-game` request, back into the response that it gives to the client
  - This way the client does not need to hold on to them
- Create two events in gameserver: `SessionOpenEvent` and `SessionCloseEvent` fired <i>after</i> session open and after session closed
  - Has a field that stores the relevant ClientSession
    - ClientSessions store the clientId, playerName, and connected gameServer
- `ClientSocketHandler#open` now requires a playerName to open a session with
- `GameSocketHandler#getSessions` now returns a `List<ClientSession>` as opposed to `Collection<UUID>`
  - This list is ordered by who joined first