### PR TITLE
Added Schema Validation for Matchmaker Endpoints

### DIFF
--- a/matchmaker/build.gradle.kts
+++ b/matchmaker/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 	// SpringBoot
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	// Redis
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("redis.clients:jedis:5.1.2")
@@ -36,6 +37,9 @@ dependencies {
 	// Lombok
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
+	// Jakarta
+	implementation("jakarta.annotation:jakarta.annotation-api:3.0.0") // Bundled in spring 3
+	implementation("jakarta.validation:jakarta.validation-api:3.1.0")
 	// K8s
 	implementation("io.kubernetes:client-java:21.0.2")
 	// Agones GRPC wrapper

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/config/GameServerRepository.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/config/GameServerRepository.java
@@ -14,7 +14,7 @@ public class GameServerRepository {
 
     private static final String PREFIX = SharedConstants.STORAGE_REDIS_GAME_SERVER_PREFIX;
 
-    private RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public GameServerRepository(RedisTemplate<String, Object> redisTemplate) {
         this.redisTemplate = redisTemplate;

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/config/RestExceptionHandler.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/config/RestExceptionHandler.java
@@ -1,0 +1,23 @@
+package dev.totallyspies.spydle.matchmaker.config;
+
+import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ClientErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
+        StringBuilder builder = new StringBuilder();
+        exception.getBindingResult().getFieldErrors().forEach(error ->
+                builder.append(error.getField()).append(": ").append(error.getDefaultMessage()).append(", "));
+        if (builder.length() >= 2) {
+            builder.delete(builder.length() - 2, builder.length());
+        }
+        return ResponseEntity.status(400).body(new ClientErrorResponse().message(builder.toString()));
+    }
+
+}

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/config/SessionRepository.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/config/SessionRepository.java
@@ -2,10 +2,10 @@ package dev.totallyspies.spydle.matchmaker.config;
 
 import dev.totallyspies.spydle.shared.SharedConstants;
 import dev.totallyspies.spydle.shared.model.ClientSession;
+import jakarta.annotation.Nullable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.annotation.Nullable;
 import java.util.UUID;
 
 @Repository

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/controller/AutoscaleController.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/controller/AutoscaleController.java
@@ -4,9 +4,11 @@ import dev.totallyspies.spydle.matchmaker.generated.model.AutoscaleRequestModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.AutoscaleResponseModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.AutoscaleResponseModelResponse;
 import dev.totallyspies.spydle.matchmaker.use_case.AutoscaleService;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
  * This endpoint is called by agones periodically to determine how many game servers we need.
  */
 @RestController
+@Validated
 public class AutoscaleController {
 
     private final Logger logger = LoggerFactory.getLogger(AutoscaleController.class);
@@ -27,7 +30,7 @@ public class AutoscaleController {
     }
 
     @PostMapping("/autoscale")
-    public ResponseEntity<?> autoscale(@RequestBody AutoscaleRequestModel request) {
+    public ResponseEntity<?> autoscale(@Valid @RequestBody AutoscaleRequestModel request) {
         logger.info("Received request: /autoscale, request: {}", request.toJson());
         try {
             int desired = autoscalerService.autoscale(request.getRequest().getStatus());

--- a/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/controller/MatchmakingController.java
+++ b/matchmaker/src/main/java/dev/totallyspies/spydle/matchmaker/controller/MatchmakingController.java
@@ -1,18 +1,20 @@
 package dev.totallyspies.spydle.matchmaker.controller;
 
+import dev.totallyspies.spydle.matchmaker.config.GameServerRepository;
+import dev.totallyspies.spydle.matchmaker.config.SessionRepository;
 import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
 import dev.totallyspies.spydle.matchmaker.generated.model.CreateGameRequestModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.CreateGameResponseModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.JoinGameRequestModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.JoinGameResponseModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.ListGamesResponseModel;
-import dev.totallyspies.spydle.matchmaker.config.GameServerRepository;
-import dev.totallyspies.spydle.matchmaker.config.SessionRepository;
 import dev.totallyspies.spydle.matchmaker.use_case.MatchmakingService;
 import dev.totallyspies.spydle.shared.model.GameServer;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +30,7 @@ import java.util.UUID;
  * leave-game: Delete a user session from a game server and notify it of client departure
  */
 @RestController
+@Validated
 public class MatchmakingController {
 
     private final Logger logger = LoggerFactory.getLogger(MatchmakingController.class);
@@ -45,7 +48,7 @@ public class MatchmakingController {
     }
 
     @PostMapping("/create-game")
-    public ResponseEntity<?> createGame(@RequestBody CreateGameRequestModel request) {
+    public ResponseEntity<?> createGame(@Valid @RequestBody CreateGameRequestModel request) {
         UUID clientId = sessionRepository.parseClientId(request.getClientId());
         logger.info("Received request: /create-game, clientId: {}", request.getClientId());
         if (clientId == null) {
@@ -66,7 +69,7 @@ public class MatchmakingController {
     }
 
     @PostMapping("/join-game")
-    public ResponseEntity<?> joinGame(@RequestBody JoinGameRequestModel request) {
+    public ResponseEntity<?> joinGame(@Valid @RequestBody JoinGameRequestModel request) {
         UUID clientId = sessionRepository.parseClientId(request.getClientId());
         logger.info("Received request: /join-game, clientId: {}, gameServerName: {}", request.getClientId(), request.getRoomCode());
         if (clientId == null) {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     // Lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
+    // Jakarta
+    implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")
+    implementation("jakarta.validation:jakarta.validation-api:3.1.0")
     // Protobuf
     implementation("com.google.protobuf:protobuf-java:4.28.3")
     implementation("com.google.code.gson:gson:2.11.0")
@@ -70,6 +73,9 @@ openApiGenerate {
 
     schemaMappings.put("GameServer", "dev.totallyspies.spydle.shared.model.GameServer")
     schemaMappings.put("ClientSession", "dev.totallyspies.spydle.shared.model.ClientSession")
+
+    configOptions.put("useJakartaEe", "true")
+    configOptions.put("useBeanValidation", "true")
 }
 
 sourceSets {


### PR DESCRIPTION
## Changes
- Added jakarta annotations and validation dependencies
- Added spring boot validation dependency
- Enabled settings in openAPI/swagger generator to use jakarta annotations (such as `@NonNull`)
- Added `@Valid` and `@Validated` annotations to rest controllers
- Added exception handler as rest controller advice to format `MethodArgumentNotValidException` exceptions as `ClientErrorResponse` (swagger spec)

## Explanation
- Previously, if you sent a `/create-game` request without providing a playerName (for example), the request would still get processed just with a null player name. This is bad.
- Now we enforce the structure of the schemas we generate with openAPI using jakarta and spring validation