### PR TITLE
Create Use-Case Interactors + Presenters with Backend for join/create/list games

### DIFF
--- a/deployment/base/ingress/ingress.yaml
+++ b/deployment/base/ingress/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: totallyspies.dev  # Replace with your domain
+    - host: spydle.kailo.ca  # Replace with your domain
       http:
         paths: # Do not expose autoscale
           - path: /create-game

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketHandler.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketHandler.java
@@ -57,7 +57,7 @@ public class ClientSocketHandler extends BinaryWebSocketHandler {
             URI uri = new URI("ws://" + address + ":" + port + SharedConstants.GAME_SOCKET_ENDPOINT);
             session = client.execute(this, headers, uri).get();
         } catch (Exception exception) {
-            throw new RuntimeException("Failed to open client socket", exception);
+            throw new RuntimeException("Failed to open client socket " + exception.getMessage(), exception);
         }
     }
 

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketHandler.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketHandler.java
@@ -59,6 +59,7 @@ public class ClientSocketHandler extends BinaryWebSocketHandler {
         } catch (Exception exception) {
             throw new RuntimeException("Failed to open client socket " + exception.getMessage(), exception);
         }
+        logger.info("Opened socket connection with gameserver at {}:{}, with client ID {} and name {}", address, port, clientId, playerName);
     }
 
     @Override

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/rest/WebClientService.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/rest/WebClientService.java
@@ -13,16 +13,16 @@ public class WebClientService {
     @Autowired
     private WebClient webClient;
 
-    public <T> T postEndpoint(String path, Object data, Class<T> responseModel) throws ClientErrorException {
+    public <T> Object postEndpoint(String path, Object data, Class<T> responseModel) throws ClientErrorException {
         return handleResponse(webClient.post().uri(formatPath(path)).bodyValue(data).retrieve(), responseModel);
 
     }
 
-    public <T> T getEndpoint(String path, Class<T> responseModel) {
+    public <T> Object getEndpoint(String path, Class<T> responseModel) {
         return handleResponse(webClient.get().uri(formatPath(path)).retrieve(), responseModel);
     }
 
-    private <T> T handleResponse(WebClient.ResponseSpec responseSpec, Class<T> responseModel) throws ClientErrorException {
+    private <T> Object handleResponse(WebClient.ResponseSpec responseSpec, Class<T> responseModel) throws ClientErrorException {
         return responseSpec
                 .onStatus(
                         HttpStatusCode::is4xxClientError,

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/rest/WebClientService.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/rest/WebClientService.java
@@ -1,6 +1,8 @@
 package dev.totallyspies.spydle.frontend.client.rest;
 
 import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
@@ -10,16 +12,21 @@ import reactor.core.publisher.Mono;
 @Service
 public class WebClientService {
 
+    private final Logger logger = LoggerFactory.getLogger(WebClientService.class);
+
     @Autowired
     private WebClient webClient;
 
     public <T> Object postEndpoint(String path, Object data, Class<T> responseModel) throws ClientErrorException {
-        return handleResponse(webClient.post().uri(formatPath(path)).bodyValue(data).retrieve(), responseModel);
-
+        Object response = handleResponse(webClient.post().uri(formatPath(path)).bodyValue(data).retrieve(), responseModel);
+        logger.info("Made POST request to {} path with {} data, got response {}", path, data, response);
+        return response;
     }
 
     public <T> Object getEndpoint(String path, Class<T> responseModel) {
-        return handleResponse(webClient.get().uri(formatPath(path)).retrieve(), responseModel);
+        Object response = handleResponse(webClient.get().uri(formatPath(path)).retrieve(), responseModel);
+        logger.info("Made GET request to {} path, got response {}", path, response);
+        return response;
     }
 
     private <T> Object handleResponse(WebClient.ResponseSpec responseSpec, Class<T> responseModel) throws ClientErrorException {

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsPresenter.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsPresenter.java
@@ -1,0 +1,32 @@
+package dev.totallyspies.spydle.frontend.interface_adapters.list_rooms;
+
+import dev.totallyspies.spydle.frontend.views.ListRoomsView;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ListRoomsPresenter {
+
+    @Autowired
+    private ListRoomsView view;
+
+    @Autowired
+    private ListRoomsViewModel model;
+
+    @EventListener
+    public void onListRoomsUpdate(ListRoomsUpdateEvent event) {
+        List<String> roomCodes = event.getRoomCodes();
+        String[] lines;
+        if (roomCodes.isEmpty()) {
+            lines = new String[] {"No Public Rooms Available"};
+        } else {
+            lines = roomCodes.toArray(new String[0]);
+        }
+        model.setLinesInRoomList(lines);
+        view.updateRoomList();
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsUpdateEvent.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsUpdateEvent.java
@@ -1,0 +1,18 @@
+package dev.totallyspies.spydle.frontend.interface_adapters.list_rooms;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+@Getter
+public class ListRoomsUpdateEvent extends ApplicationEvent {
+
+    private final List<String> roomCodes;
+
+    public ListRoomsUpdateEvent(Object source, List<String> roomCodes) {
+        super(source);
+        this.roomCodes = roomCodes;
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewController.java
@@ -1,6 +1,8 @@
 package dev.totallyspies.spydle.frontend.interface_adapters.list_rooms;
 
 import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.SwitchViewEvent;
+import dev.totallyspies.spydle.frontend.use_cases.list_games.ListGamesInteractor;
+import dev.totallyspies.spydle.frontend.use_cases.list_games.ListGamesOutputData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -11,11 +13,19 @@ public class ListRoomsViewController {
     @Autowired
     private ApplicationEventPublisher publisher;
 
+    @Autowired
+    private ListGamesInteractor listGamesInteractor;
+
     /*
     Method called when View All Rooms Button is Pressed
      */
     public void openWelcomeView() {
         publisher.publishEvent(new SwitchViewEvent(this, "WelcomeView"));
+    }
+
+    public void updateRoomList() {
+        ListGamesOutputData output = listGamesInteractor.execute();
+        publisher.publishEvent(new ListRoomsUpdateEvent(this, output.getRoomCodes()));
     }
 
 }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewModel.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Component;
 @Data
 public class ListRoomsViewModel {
 
+    private String[] linesInRoomList;
+
 }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ErrorViewEvent.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ErrorViewEvent.java
@@ -1,0 +1,16 @@
+package dev.totallyspies.spydle.frontend.interface_adapters.view_manager;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class ErrorViewEvent extends ApplicationEvent {
+
+    private final String message;
+
+    public ErrorViewEvent(Object source, String message) {
+        super(source);
+        this.message = message;
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ViewManagerModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ViewManagerModel.java
@@ -69,12 +69,12 @@ public class ViewManagerModel extends JFrame {
         JOptionPane.showMessageDialog(this, event.getMessage());
     }
 
-    public static void launchGameView(String[] args) {
-        // Run the GameWindowFrame
-        SwingUtilities.invokeLater(() -> {
-            ViewManagerModel frame = new ViewManagerModel(new WelcomeView(), new GameRoomView(), new ListRoomsView(), new GameEndView());
-            frame.setVisible(true);
-        });
-    }
+//    public static void launchGameView(String[] args) {
+//        // Run the GameWindowFrame
+//        SwingUtilities.invokeLater(() -> {
+//            ViewManagerModel frame = new ViewManagerModel(new WelcomeView(), new GameRoomView(), new ListRoomsView(), new GameEndView());
+//            frame.setVisible(true);
+//        });
+//    }
 
 }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ViewManagerModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ViewManagerModel.java
@@ -63,6 +63,11 @@ public class ViewManagerModel extends JFrame {
         cardLayout.show(panelContainer, event.getViewName());
     }
 
+    @EventListener
+    public void handleViewError(ErrorViewEvent event) {
+        JOptionPane.showMessageDialog(this, event.getMessage());
+    }
+
     public static void launchGameView(String[] args) {
         // Run the GameWindowFrame
         SwingUtilities.invokeLater(() -> {

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewController.java
@@ -1,6 +1,20 @@
 package dev.totallyspies.spydle.frontend.interface_adapters.welcome;
 
+import dev.totallyspies.spydle.frontend.client.ClientSocketHandler;
 import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.SwitchViewEvent;
+import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.ErrorViewEvent;
+import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameInputData;
+import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameInteractor;
+import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameOutputData;
+import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameOutputDataFail;
+import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameOutputDataSuccess;
+import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameInputData;
+import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameInteractor;
+import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameOutputData;
+import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameOutputDataFail;
+import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameOutputDataSuccess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -8,14 +22,88 @@ import org.springframework.stereotype.Component;
 @Component
 public class WelcomeViewController {
 
+    private final Logger logger = LoggerFactory.getLogger(WelcomeViewController.class);
+
     @Autowired
     private ApplicationEventPublisher publisher;
+
+    @Autowired
+    private WelcomeViewModel model;
+
+    @Autowired
+    private CreateGameInteractor createGameInteractor;
+
+    @Autowired
+    private JoinGameInteractor joinGameInteractor;
+
+    @Autowired
+    private ClientSocketHandler socketHandler;
 
     /*
     Method called when View All Rooms Button is Pressed
      */
     public void openListRoomsView() {
         publisher.publishEvent(new SwitchViewEvent(this, "ListRoomsView"));
+    }
+
+    public void createGame() {
+        if (model.getPlayerName().isBlank() || model.getPlayerName().length() > 32) {
+            fireError("Invalid player name: \"" + model.getPlayerName() + "\"");
+            return;
+        }
+        CreateGameInputData input = new CreateGameInputData(model.getPlayerName());
+        CreateGameOutputData output = createGameInteractor.execute(input);
+        if (output instanceof CreateGameOutputDataSuccess successOutput) {
+            try {
+                socketHandler.open(
+                        successOutput.getGameHost(),
+                        successOutput.getGamePort(),
+                        successOutput.getClientId(),
+                        successOutput.getPlayerName()
+                );
+                publisher.publishEvent(new SwitchViewEvent(this, "GameRoomView"));
+            } catch (Exception exception) {
+                fireError("Failed to connect to game server: " + exception.getMessage());
+                logger.error("Failed to connect to game server: ", exception);
+            }
+        } else {
+            CreateGameOutputDataFail failOutput = (CreateGameOutputDataFail) output;
+            fireError("Failed to send request to matchmaker:\n" + failOutput.getMessage());
+        }
+    }
+
+    public void joinGame() {
+        if (model.getPlayerName().isBlank() || model.getPlayerName().length() > 32) {
+            fireError("Invalid player name: \"" + model.getPlayerName() + "\"");
+            return;
+        }
+        if (model.getRoomCode().isBlank() || model.getRoomCode().length() != 5) {
+            fireError("Invalid room code: \"" + model.getRoomCode() + "\"");
+            return;
+        }
+        JoinGameInputData input = new JoinGameInputData(model.getPlayerName(), model.getRoomCode());
+        JoinGameOutputData output = joinGameInteractor.execute(input);
+        if (output instanceof JoinGameOutputDataSuccess successOutput) {
+            try {
+                socketHandler.open(
+                        successOutput.getGameHost(),
+                        successOutput.getGamePort(),
+                        successOutput.getClientId(),
+                        successOutput.getPlayerName()
+                );
+                publisher.publishEvent(new SwitchViewEvent(this, "GameRoomView"));
+            } catch (Exception exception) {
+                fireError("Failed to connect to game server: " + exception.getMessage());
+                logger.error("Failed to connect to game server: ", exception);
+            }
+        } else {
+            JoinGameOutputDataFail failOutput = (JoinGameOutputDataFail) output;
+            fireError("Failed to send request to matchmaker:\n" + failOutput.getMessage());
+        }
+    }
+
+    private void fireError(String message) {
+        publisher.publishEvent(new ErrorViewEvent(this, message));
     }
 
 }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewModel.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Data
 public class WelcomeViewModel {
 
-    private String playerName;
-    private String roomCode;
+    private String playerName = "";
+    private String roomCode = "";
 
 }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/CreateGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/CreateGameInteractor.java
@@ -1,5 +1,0 @@
-package dev.totallyspies.spydle.frontend.use_cases;
-
-public class CreateGameInteractor {
-
-}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/JoinGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/JoinGameInteractor.java
@@ -1,5 +1,0 @@
-package dev.totallyspies.spydle.frontend.use_cases;
-
-public class JoinGameInteractor {
-
-}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInputBoundary.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInputBoundary.java
@@ -1,0 +1,7 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+public interface CreateGameInputBoundary {
+
+    CreateGameOutputData execute(CreateGameInputData data);
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInputData.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInputData.java
@@ -1,0 +1,12 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CreateGameInputData {
+
+    private String playerName;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
@@ -1,0 +1,38 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+import dev.totallyspies.spydle.frontend.client.rest.WebClientService;
+import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
+import dev.totallyspies.spydle.matchmaker.generated.model.CreateGameRequestModel;
+import dev.totallyspies.spydle.matchmaker.generated.model.CreateGameResponseModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class CreateGameInteractor implements CreateGameInputBoundary {
+
+    @Autowired
+    private WebClientService webClient;
+
+    @Override
+    public CreateGameOutputData execute(CreateGameInputData data) {
+        UUID clientId = UUID.randomUUID();
+        CreateGameRequestModel request = new CreateGameRequestModel()
+                .clientId(clientId.toString())
+                .playerName(data.getPlayerName());
+        Object response = webClient.postEndpoint("/create-game", request, CreateGameResponseModel.class);
+        if (response instanceof CreateGameResponseModel responseModel) {
+            return new CreateGameOutputDataSuccess(
+                    responseModel.getGameServer().getAddress(), // TODO fix
+                    responseModel.getGameServer().getPort(),
+                    UUID.fromString(responseModel.getClientId()),
+                    responseModel.getPlayerName()
+            );
+        } else if (response instanceof ClientErrorResponse clientErrorModel) {
+            return new CreateGameOutputDataFail(clientErrorModel.getMessage());
+        }
+        return new CreateGameOutputDataFail(response.toString());
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
@@ -5,12 +5,16 @@ import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
 import dev.totallyspies.spydle.matchmaker.generated.model.CreateGameRequestModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.CreateGameResponseModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
 @Component
 public class CreateGameInteractor implements CreateGameInputBoundary {
+
+    @Value("${server.backend.gameserver-overwrite}")
+    private String gameServerOverwrite;
 
     @Autowired
     private WebClientService webClient;
@@ -23,8 +27,11 @@ public class CreateGameInteractor implements CreateGameInputBoundary {
                 .playerName(data.getPlayerName());
         Object response = webClient.postEndpoint("/create-game", request, CreateGameResponseModel.class);
         if (response instanceof CreateGameResponseModel responseModel) {
+            String ip = gameServerOverwrite == null || gameServerOverwrite.isBlank()
+                    ? responseModel.getGameServer().getAddress()
+                    : gameServerOverwrite;
             return new CreateGameOutputDataSuccess(
-                    responseModel.getGameServer().getAddress(), // TODO fix
+                    ip,
                     responseModel.getGameServer().getPort(),
                     UUID.fromString(responseModel.getClientId()),
                     responseModel.getPlayerName()

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameOutputData.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameOutputData.java
@@ -1,0 +1,4 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+public sealed interface CreateGameOutputData permits CreateGameOutputDataFail, CreateGameOutputDataSuccess {
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameOutputDataFail.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameOutputDataFail.java
@@ -1,0 +1,12 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public final class CreateGameOutputDataFail implements CreateGameOutputData {
+
+    private String message;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameOutputDataSuccess.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameOutputDataSuccess.java
@@ -1,0 +1,17 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public final class CreateGameOutputDataSuccess implements CreateGameOutputData {
+
+    private String gameHost;
+    private int gamePort;
+    private UUID clientId;
+    private String playerName;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInputBoundary.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInputBoundary.java
@@ -1,0 +1,7 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+public interface JoinGameInputBoundary {
+
+    JoinGameOutputData execute(JoinGameInputData data);
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInputData.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInputData.java
@@ -1,0 +1,13 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JoinGameInputData {
+
+    private String playerName;
+    private String roomCode;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
@@ -5,12 +5,16 @@ import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
 import dev.totallyspies.spydle.matchmaker.generated.model.JoinGameRequestModel;
 import dev.totallyspies.spydle.matchmaker.generated.model.JoinGameResponseModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
 @Component
 public class JoinGameInteractor implements JoinGameInputBoundary {
+
+    @Value("${server.backend.gameserver-overwrite}")
+    private String gameServerOverwrite;
 
     @Autowired
     private WebClientService webClient;
@@ -24,8 +28,11 @@ public class JoinGameInteractor implements JoinGameInputBoundary {
                 .roomCode(data.getRoomCode());
         Object response = webClient.postEndpoint("/create-game", request, JoinGameResponseModel.class);
         if (response instanceof JoinGameResponseModel responseModel) {
+            String ip = gameServerOverwrite == null || gameServerOverwrite.isBlank()
+                    ? responseModel.getGameServer().getAddress()
+                    : gameServerOverwrite;
             return new JoinGameOutputDataSuccess(
-                    responseModel.getGameServer().getAddress(), // TODO fix
+                    ip,
                     responseModel.getGameServer().getPort(),
                     UUID.fromString(responseModel.getClientId()),
                     responseModel.getPlayerName()

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
@@ -1,0 +1,39 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+import dev.totallyspies.spydle.frontend.client.rest.WebClientService;
+import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
+import dev.totallyspies.spydle.matchmaker.generated.model.JoinGameRequestModel;
+import dev.totallyspies.spydle.matchmaker.generated.model.JoinGameResponseModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class JoinGameInteractor implements JoinGameInputBoundary {
+
+    @Autowired
+    private WebClientService webClient;
+
+    @Override
+    public JoinGameOutputData execute(JoinGameInputData data) {
+        UUID clientId = UUID.randomUUID();
+        JoinGameRequestModel request = new JoinGameRequestModel()
+                .clientId(clientId.toString())
+                .playerName(data.getPlayerName())
+                .roomCode(data.getRoomCode());
+        Object response = webClient.postEndpoint("/create-game", request, JoinGameResponseModel.class);
+        if (response instanceof JoinGameResponseModel responseModel) {
+            return new JoinGameOutputDataSuccess(
+                    responseModel.getGameServer().getAddress(), // TODO fix
+                    responseModel.getGameServer().getPort(),
+                    UUID.fromString(responseModel.getClientId()),
+                    responseModel.getPlayerName()
+            );
+        } else if (response instanceof ClientErrorResponse clientErrorModel) {
+            return new JoinGameOutputDataFail(clientErrorModel.getMessage());
+        }
+        return new JoinGameOutputDataFail(response.toString());
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameOutputData.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameOutputData.java
@@ -1,0 +1,4 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+public sealed interface JoinGameOutputData permits JoinGameOutputDataFail, JoinGameOutputDataSuccess {
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameOutputDataFail.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameOutputDataFail.java
@@ -1,0 +1,12 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public final class JoinGameOutputDataFail implements JoinGameOutputData {
+
+    private String message;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameOutputDataSuccess.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameOutputDataSuccess.java
@@ -1,0 +1,17 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public final class JoinGameOutputDataSuccess implements JoinGameOutputData {
+
+    private String gameHost;
+    private int gamePort;
+    private UUID clientId;
+    private String playerName;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInputBoundary.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInputBoundary.java
@@ -1,0 +1,7 @@
+package dev.totallyspies.spydle.frontend.use_cases.list_games;
+
+public interface ListGamesInputBoundary {
+
+    ListGamesOutputData execute();
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
@@ -1,0 +1,28 @@
+package dev.totallyspies.spydle.frontend.use_cases.list_games;
+
+import dev.totallyspies.spydle.frontend.client.rest.WebClientService;
+import dev.totallyspies.spydle.matchmaker.generated.model.ClientErrorResponse;
+import dev.totallyspies.spydle.matchmaker.generated.model.ListGamesResponseModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedList;
+
+@Component
+public class ListGamesInteractor implements ListGamesInputBoundary {
+
+    @Autowired
+    public WebClientService webClient;
+
+    @Override
+    public ListGamesOutputData execute() {
+        Object response = webClient.getEndpoint("/list-games", ListGamesResponseModel.class);
+        if (response instanceof ListGamesResponseModel responseModel) {
+            return new ListGamesOutputData(responseModel.getRoomCodes());
+        } else if (response instanceof ClientErrorResponse clientErrorModel) {
+            return new ListGamesOutputData(new LinkedList<>());
+        }
+        return new ListGamesOutputData(new LinkedList<>());
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesOutputData.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesOutputData.java
@@ -1,0 +1,14 @@
+package dev.totallyspies.spydle.frontend.use_cases.list_games;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ListGamesOutputData {
+
+    private List<String> roomCodes;
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/ListRoomsView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/ListRoomsView.java
@@ -2,25 +2,28 @@ package dev.totallyspies.spydle.frontend.views;
 
 import dev.totallyspies.spydle.frontend.interface_adapters.list_rooms.ListRoomsViewController;
 import dev.totallyspies.spydle.frontend.interface_adapters.list_rooms.ListRoomsViewModel;
+import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.SwitchViewEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 
 @org.springframework.stereotype.Component
 public class ListRoomsView extends JPanel {
 
-    @Autowired
-    private ListRoomsViewController controller;
-
-    @Autowired
-    private ListRoomsViewModel model;
+    private final ListRoomsViewController controller;
+    private final ListRoomsViewModel model;
 
     private JList<String> roomList;
 
-    public ListRoomsView() {
+    public ListRoomsView(ListRoomsViewModel model, ListRoomsViewController controller) {
+        this.controller = controller;
+        this.model = model;
+
         setLayout(new GridBagLayout()); // Center the container in the middle of the screen
         setBackground(new Color(195, 217, 255)); // Light blue background for the entire panel
 
@@ -77,6 +80,18 @@ public class ListRoomsView extends JPanel {
         add(container, gbc);
     }
 
+    @EventListener
+    public void onApplicationReady(ApplicationReadyEvent event) {
+        controller.updateRoomList();
+    }
+
+    @EventListener
+    public void onSwitchView(SwitchViewEvent event) {
+        if (event.getViewName().equals("ListRoomsView")) {
+            controller.updateRoomList();
+        }
+    }
+
     private void styleButton(JButton button) {
         button.setBackground(new Color(138, 43, 226)); // blueviolet
         button.setForeground(Color.WHITE);
@@ -109,16 +124,16 @@ public class ListRoomsView extends JPanel {
         roomList.setListData(model.getLinesInRoomList());
     }
 
-    // Test the JPanel in a JFrame with size 500x500
-    public static void main(String[] args) {
-        SwingUtilities.invokeLater(() -> {
-            JFrame frame = new JFrame("Spydle - All Rooms");
-            frame.setSize(800, 600);
-            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-            frame.setLocationRelativeTo(null);
-            frame.add(new ListRoomsView());
-            frame.setVisible(true);
-        });
-    }
+//    // Test the JPanel in a JFrame with size 500x500
+//    public static void main(String[] args) {
+//        SwingUtilities.invokeLater(() -> {
+//            JFrame frame = new JFrame("Spydle - All Rooms");
+//            frame.setSize(800, 600);
+//            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+//            frame.setLocationRelativeTo(null);
+//            frame.add(new ListRoomsView());
+//            frame.setVisible(true);
+//        });
+//    }
 
 }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/ListRoomsView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/ListRoomsView.java
@@ -1,6 +1,7 @@
 package dev.totallyspies.spydle.frontend.views;
 
 import dev.totallyspies.spydle.frontend.interface_adapters.list_rooms.ListRoomsViewController;
+import dev.totallyspies.spydle.frontend.interface_adapters.list_rooms.ListRoomsViewModel;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.swing.*;
@@ -13,6 +14,11 @@ public class ListRoomsView extends JPanel {
 
     @Autowired
     private ListRoomsViewController controller;
+
+    @Autowired
+    private ListRoomsViewModel model;
+
+    private JList<String> roomList;
 
     public ListRoomsView() {
         setLayout(new GridBagLayout()); // Center the container in the middle of the screen
@@ -30,16 +36,15 @@ public class ListRoomsView extends JPanel {
         titleLabel.setForeground(new Color(139, 0, 0)); // Dark red color
         titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-        // Fake room data with the format "Room 1: Name"
+        // Fake room data
         String[] roomData = {
-                "Room 1: When you wake up",
-                "Room 2: Next to him",
-                "Room 3: In the middle",
-                "Room 4: Of the night"
+                "Loading..."
         };
 
+        model.setLinesInRoomList(roomData);
+
         // Create JList with fake data
-        JList<String> roomList = new JList<>(roomData);
+        roomList = new JList<>(roomData);
         roomList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         roomList.setFont(new Font("Arial", Font.PLAIN, 16));
 
@@ -98,6 +103,10 @@ public class ListRoomsView extends JPanel {
                 button.setForeground(Color.WHITE);
             }
         });
+    }
+
+    public void updateRoomList() {
+        roomList.setListData(model.getLinesInRoomList());
     }
 
     // Test the JPanel in a JFrame with size 500x500

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/WelcomeView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/WelcomeView.java
@@ -47,7 +47,6 @@ public class WelcomeView extends JPanel {
 
             private void updateNickname() {
                 welcomeViewModel.setPlayerName(nicknameField.getText());
-                System.out.println("Nickname: " + welcomeViewModel.getPlayerName());
             }
         });
 
@@ -65,7 +64,6 @@ public class WelcomeView extends JPanel {
 
                 if (isEnter) {
                     welcomeMessageLabel.setText("Welcome " + welcomeViewModel.getPlayerName() + "!");
-                    System.out.println("Welcome " + welcomeViewModel.getPlayerName());
                     enterButton.setText("Cancel");
                     isEnter = false;
                 } else {
@@ -103,7 +101,7 @@ public class WelcomeView extends JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 welcomeViewModel.setRoomCode(nicknameField.getText());
-                System.out.println("Create Room button clicked with nickname: " + welcomeViewModel.getPlayerName());
+                controller.createGame();
             }
         });
 
@@ -121,7 +119,6 @@ public class WelcomeView extends JPanel {
 
             private void updateRoomCode() {
                 welcomeViewModel.setRoomCode(roomCodeField.getText());
-                System.out.println("Room Code: " + welcomeViewModel.getRoomCode());
             }
         });
 
@@ -133,7 +130,7 @@ public class WelcomeView extends JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 welcomeViewModel.setRoomCode(roomCodeField.getText());
-                System.out.println("Join Room button clicked with room code: " + welcomeViewModel.getRoomCode());
+                controller.joinGame();
             }
         });
 
@@ -148,7 +145,6 @@ public class WelcomeView extends JPanel {
         viewAllRoomsButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                System.out.println("View All Rooms button clicked");
                 controller.openListRoomsView();
             }
         });

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/WelcomeView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/WelcomeView.java
@@ -16,17 +16,16 @@ import java.awt.event.FocusListener;
 @org.springframework.stereotype.Component
 public class WelcomeView extends JPanel {
 
-    @Autowired
-    private WelcomeViewController controller;
-
-    @Autowired
-    private WelcomeViewModel welcomeViewModel;
+    private final WelcomeViewController controller;
+    private final WelcomeViewModel welcomeViewModel;
 
     private JTextField nicknameField;
     private JTextField roomCodeField;
     private JLabel welcomeMessageLabel; // New label for welcome message
 
-    public WelcomeView() {
+    public WelcomeView(WelcomeViewController controller, WelcomeViewModel welcomeViewModel) {
+        this.controller = controller;
+        this.welcomeViewModel = welcomeViewModel;
         JPanel container = new JPanel();
         container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
         container.setBorder(BorderFactory.createEmptyBorder(30, 30, 30, 30));
@@ -217,16 +216,16 @@ public class WelcomeView extends JPanel {
         });
     }
 
-    public static void main(String[] args) {
-        SwingUtilities.invokeLater(() -> {
-            JFrame frame = new JFrame();
-            frame.setTitle("Welcome - Join or Create Room");
-            frame.setSize(800, 600); // Set frame size to 800x600
-            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-            frame.setLocationRelativeTo(null);
-            // Add the WelcomeView panel with light blue background
-            frame.add(new WelcomeView());
-            frame.setVisible(true);
-        });
-    }
+//    public static void main(String[] args) {
+//        SwingUtilities.invokeLater(() -> {
+//            JFrame frame = new JFrame();
+//            frame.setTitle("Welcome - Join or Create Room");
+//            frame.setSize(800, 600); // Set frame size to 800x600
+//            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+//            frame.setLocationRelativeTo(null);
+//            // Add the WelcomeView panel with light blue background
+//            frame.add(new WelcomeView());
+//            frame.setVisible(true);
+//        });
+//    }
 }

--- a/frontend/src/main/resources/application-dev.properties
+++ b/frontend/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+logging.level.dev.totallyspies.spydle.frontend=DEBUG

--- a/frontend/src/main/resources/application.properties
+++ b/frontend/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.main.web-application-type=reactive
 server.backend.url=http://34.130.129.151
 server.backend.host=spydle.kailo.ca
 server.backend.port=80
+# Leave blank for don't overwrite from MM response
+server.backend.gameserver-overwrite=34.130.129.151

--- a/frontend/src/main/resources/application.properties
+++ b/frontend/src/main/resources/application.properties
@@ -3,6 +3,6 @@ spring.application.name=gameserver
 logging.level.dev.totallyspies.spydle.frontend=INFO
 spring.main.web-application-type=reactive
 
-server.backend.url=http://spydle.kailo.ca
+server.backend.url=http://34.130.129.151
 server.backend.host=spydle.kailo.ca
 server.backend.port=80

--- a/frontend/src/main/resources/application.properties
+++ b/frontend/src/main/resources/application.properties
@@ -2,6 +2,6 @@ spring.application.name=gameserver
 
 spring.main.web-application-type=reactive
 
-server.backend.url=http://totallyspies.dev
-server.backend.host=totallyspies.dev
+server.backend.url=http://spydle.kailo.ca
+server.backend.host=spydle.kailo.ca
 server.backend.port=80


### PR DESCRIPTION
- Created use case interactors for:
  - Listing rooms
    - Sends a GET request to `/list-games` using our web client
    - Updates the list games view using its presenter
  - Creating and joining games
    - Sends a POST request to `/create-game` or `/join-game` using our web client
    - Data for the request comes from the welcome view model
    - Once it has received a response, either establishes a websocket and switches to the game room view, or gives an error message

Fully tested with the backend! All the buttons work.