### PR TITLE
Deployment Fixes

### DIFF
--- a/deployment/base/ingress/ingress.yaml
+++ b/deployment/base/ingress/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: totallyspies.dev  # Replace with your domain
+    - host: spydle.kailo.ca  # Replace with your domain
       http:
         paths: # Do not expose autoscale
           - path: /create-game

--- a/deployment/base/matchmaker/matchmaker-hpa.yaml
+++ b/deployment/base/matchmaker/matchmaker-hpa.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Deployment
     name: matchmaker
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 4
   metrics:
     - type: Resource
       resource:

--- a/deployment/env/dev/matchmaker/matchmaker-hpa.yaml
+++ b/deployment/env/dev/matchmaker/matchmaker-hpa.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: spydle
 spec:
   minReplicas: 1
-  maxReplicas: 10
+  maxReplicas: 3

--- a/deployment/install-k3s.sh
+++ b/deployment/install-k3s.sh
@@ -1,2 +1,2 @@
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -s -
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik --disable-network-policy" sh -s -
 sudo chmod 755 /etc/rancher/k3s/k3s.yaml

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker build -f gameserver.Dockerfile -t gameserver:latest .
+docker save gameserver:latest | sudo k3s ctr images import -
+docker build -f matchmaker.Dockerfile -t matchmaker:latest .
+docker save matchmaker:latest | sudo k3s ctr images import -
+kubectl apply --server-side -k deployment/env/dev --force-conflicts


### PR DESCRIPTION
- Decrease max matchmakers to prevent insufficient node resources
- Change host to expect `spydle.kailo.ca` instead of `totallyspies.dev`
- Added rebuild script to make deployment more convenient

And finally, this took me 3-4 hours of debugging to figure out why we can't connect to gameservers:
- Disabled K3s built-in kube-route network policy controller. This allows external traffic to be routed directly on to the node, and ensures our IPTABLES rules are actually respected.