### PR TITLE
Fixed Unit Tests for MatchMaker With New Client Session States

### DIFF
--- a/matchmaker/src/test/java/dev/totallyspies/spydle/matchmaker/config/SessionRepositoryTest.java
+++ b/matchmaker/src/test/java/dev/totallyspies/spydle/matchmaker/config/SessionRepositoryTest.java
@@ -36,7 +36,7 @@ public class SessionRepositoryTest {
 
     @Test
     public void testSaveSession() {
-        ClientSession session = new ClientSession(UUID.randomUUID(), fakeGameServer, "");
+        ClientSession session = new ClientSession(UUID.randomUUID(), fakeGameServer, "", ClientSession.State.ASSIGNED);
         session.setClientId(UUID.randomUUID());
         String key = SharedConstants.STORAGE_REDIS_SESSION_PREFIX + session.getClientId();
 
@@ -48,7 +48,7 @@ public class SessionRepositoryTest {
     @Test
     public void testGetSession() {
         UUID clientId = UUID.randomUUID();
-        ClientSession session = new ClientSession(clientId, fakeGameServer, "");
+        ClientSession session = new ClientSession(clientId, fakeGameServer, "", ClientSession.State.ASSIGNED);
         String key = SharedConstants.STORAGE_REDIS_SESSION_PREFIX + clientId;
 
         when(valueOperations.get(key)).thenReturn(session);

--- a/matchmaker/src/test/java/dev/totallyspies/spydle/matchmaker/use_case/MatchmakingServiceTest.java
+++ b/matchmaker/src/test/java/dev/totallyspies/spydle/matchmaker/use_case/MatchmakingServiceTest.java
@@ -41,7 +41,7 @@ public class MatchmakingServiceTest {
 
         // Mock behavior
         when(sessionRepository.sessionExists(clientId)).thenReturn(false);
-        when(allocator.awaitAllocation(5000)).thenReturn(fakeGameServer);
+        when(allocator.awaitAllocation(anyInt())).thenReturn(fakeGameServer);
 
         // Call method
         GameServer result = matchmakingService.createGame(clientId, playerName);
@@ -84,7 +84,7 @@ public class MatchmakingServiceTest {
         // Mock existing session in ASSIGNED state
         when(sessionRepository.sessionExists(clientId)).thenReturn(true);
         when(sessionRepository.getSession(clientId)).thenReturn(fakeClientSession);
-        when(allocator.awaitAllocation(5000)).thenReturn(fakeGameServer);
+        when(allocator.awaitAllocation(anyInt())).thenReturn(fakeGameServer);
 
         // Call method
         GameServer result = matchmakingService.createGame(clientId, playerName);

--- a/matchmaker/src/test/java/dev/totallyspies/spydle/matchmaker/use_case/MatchmakingServiceTest.java
+++ b/matchmaker/src/test/java/dev/totallyspies/spydle/matchmaker/use_case/MatchmakingServiceTest.java
@@ -6,12 +6,9 @@ import dev.totallyspies.spydle.shared.model.ClientSession;
 import dev.totallyspies.spydle.shared.model.GameServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
+import org.mockito.*;
 import java.util.List;
 import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -29,6 +26,7 @@ public class MatchmakingServiceTest {
     private GameServerRepository gameServerRepository;
 
     private final GameServer fakeGameServer = new GameServer("", 0, "", "", false, GameServer.State.WAITING);
+    private final ClientSession fakeClientSession = new ClientSession(UUID.randomUUID(), fakeGameServer, "player", ClientSession.State.ASSIGNED);
 
     @BeforeEach
     public void setUp() {
@@ -41,25 +39,65 @@ public class MatchmakingServiceTest {
         UUID clientId = UUID.randomUUID();
         String playerName = "Player1";
 
+        // Mock behavior
         when(sessionRepository.sessionExists(clientId)).thenReturn(false);
-        when(allocator.awaitAllocation(anyInt())).thenReturn(fakeGameServer);
+        when(allocator.awaitAllocation(5000)).thenReturn(fakeGameServer);
 
+        // Call method
         GameServer result = matchmakingService.createGame(clientId, playerName);
 
+        // Verify
         assertEquals(fakeGameServer, result);
-        verify(sessionRepository).saveSession(any(ClientSession.class));
+        verify(sessionRepository).saveSession(argThat(session ->
+                session.getClientId().equals(clientId)
+                        && session.getGameServer().equals(fakeGameServer)
+                        && session.getPlayerName().equals(playerName)
+                        && session.getState() == ClientSession.State.ASSIGNED
+        ));
     }
 
     @Test
-    public void testCreateGame_AlreadyInGame() {
+    public void testCreateGame_ClientAlreadyConnected() {
         UUID clientId = UUID.randomUUID();
         String playerName = "Player1";
 
+        // Mock existing session in CONNECTED state
         when(sessionRepository.sessionExists(clientId)).thenReturn(true);
+        ClientSession existingSession = fakeClientSession.toBuilder().state(ClientSession.State.CONNECTED).build();
+        when(sessionRepository.getSession(clientId)).thenReturn(existingSession);
 
-        assertThrows(IllegalStateException.class, () -> matchmakingService.createGame(clientId, playerName));
+        // Call method and expect exception
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            matchmakingService.createGame(clientId, playerName);
+        });
 
-        verify(sessionRepository, never()).saveSession(any(ClientSession.class));
+        assertEquals("Client is already connected to a game.", exception.getMessage());
+        verify(sessionRepository, never()).saveSession(any());
+        verify(sessionRepository, never()).deleteSession(clientId);
+    }
+
+    @Test
+    public void testCreateGame_ClientAssignedSession() {
+        UUID clientId = UUID.randomUUID();
+        String playerName = "Player1";
+
+        // Mock existing session in ASSIGNED state
+        when(sessionRepository.sessionExists(clientId)).thenReturn(true);
+        when(sessionRepository.getSession(clientId)).thenReturn(fakeClientSession);
+        when(allocator.awaitAllocation(5000)).thenReturn(fakeGameServer);
+
+        // Call method
+        GameServer result = matchmakingService.createGame(clientId, playerName);
+
+        // Verify
+        assertEquals(fakeGameServer, result);
+        verify(sessionRepository).deleteSession(clientId);
+        verify(sessionRepository).saveSession(argThat(session ->
+                session.getClientId().equals(clientId)
+                        && session.getGameServer().equals(fakeGameServer)
+                        && session.getPlayerName().equals(playerName)
+                        && session.getState() == ClientSession.State.ASSIGNED
+        ));
     }
 
     @Test
@@ -67,42 +105,89 @@ public class MatchmakingServiceTest {
         UUID clientId = UUID.randomUUID();
         String playerName = "Player1";
 
+        // Mock behavior
         when(sessionRepository.sessionExists(clientId)).thenReturn(false);
 
+        // Call method
         matchmakingService.joinGame(clientId, playerName, fakeGameServer);
 
-        verify(sessionRepository).saveSession(any(ClientSession.class));
+        // Verify
+        verify(sessionRepository).saveSession(argThat(session ->
+                session.getClientId().equals(clientId)
+                        && session.getGameServer().equals(fakeGameServer)
+                        && session.getPlayerName().equals(playerName)
+                        && session.getState() == ClientSession.State.ASSIGNED
+        ));
     }
 
     @Test
-    public void testJoinGame_AlreadyInGame() {
+    public void testJoinGame_ClientAlreadyConnected() {
         UUID clientId = UUID.randomUUID();
         String playerName = "Player1";
 
+        // Mock existing session in CONNECTED state
         when(sessionRepository.sessionExists(clientId)).thenReturn(true);
+        ClientSession existingSession = fakeClientSession.toBuilder().state(ClientSession.State.CONNECTED).build();
+        when(sessionRepository.getSession(clientId)).thenReturn(existingSession);
 
-        assertThrows(IllegalStateException.class, () -> matchmakingService.joinGame(clientId, playerName, fakeGameServer));
+        // Call method and expect exception
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            matchmakingService.joinGame(clientId, playerName, fakeGameServer);
+        });
 
-        verify(sessionRepository, never()).saveSession(any(ClientSession.class));
+        assertEquals("Client is already connected to a game.", exception.getMessage());
+        verify(sessionRepository, never()).saveSession(any());
+        verify(sessionRepository, never()).deleteSession(clientId);
+    }
+
+    @Test
+    public void testJoinGame_ClientAssignedSession() {
+        UUID clientId = UUID.randomUUID();
+        String playerName = "Player1";
+
+        // Mock existing session in ASSIGNED state
+        when(sessionRepository.sessionExists(clientId)).thenReturn(true);
+        when(sessionRepository.getSession(clientId)).thenReturn(fakeClientSession);
+
+        // Call method
+        matchmakingService.joinGame(clientId, playerName, fakeGameServer);
+
+        // Verify
+        verify(sessionRepository).deleteSession(clientId);
+        verify(sessionRepository).saveSession(argThat(session ->
+                session.getClientId().equals(clientId)
+                        && session.getGameServer().equals(fakeGameServer)
+                        && session.getPlayerName().equals(playerName)
+                        && session.getState() == ClientSession.State.ASSIGNED
+        ));
     }
 
     @Test
     public void testListGames() {
         GameServer gameServer1 = mock(GameServer.class);
         GameServer gameServer2 = mock(GameServer.class);
+        GameServer gameServer3 = mock(GameServer.class);
 
-        when(gameServerRepository.getGameServers()).thenReturn(List.of(gameServer1, gameServer2));
+        // Mock list of game servers
+        when(gameServerRepository.getGameServers()).thenReturn(List.of(gameServer1, gameServer2, gameServer3));
 
+        // Configure gameServer1 to match criteria
         when(gameServer1.isPublicRoom()).thenReturn(true);
         when(gameServer1.getState()).thenReturn(GameServer.State.WAITING);
         when(gameServer1.getRoomCode()).thenReturn("ROOM1");
 
+        // Configure gameServer2 to not match criteria
         when(gameServer2.isPublicRoom()).thenReturn(false);
 
-        List<String> games = matchmakingService.listGames();
+        // Configure gameServer3 to not match criteria
+        when(gameServer3.isPublicRoom()).thenReturn(true);
+        when(gameServer3.getState()).thenReturn(GameServer.State.PLAYING);
 
-        assertEquals(1, games.size());
-        assertEquals("ROOM1", games.get(0));
+        // Call method
+        List<String> roomCodes = matchmakingService.listGames();
+
+        // Verify
+        assertEquals(1, roomCodes.size());
+        assertEquals("ROOM1", roomCodes.get(0));
     }
-
 }

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/model/ClientSession.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/model/ClientSession.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 public class ClientSession implements Serializable {
 


### PR DESCRIPTION
With the changes in #33, this broke some of the unit tests written in #43.
This fixes those broken tests.