### PR TITLE
Added Shutdown GameServer Logic When All Players Leave

### DIFF
--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/agones/AgonesHealthController.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/agones/AgonesHealthController.java
@@ -1,10 +1,10 @@
-package dev.totallyspies.spydle.gameserver.controller;
+package dev.totallyspies.spydle.gameserver.agones;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class HealthController {
+public class AgonesHealthController {
 
     @GetMapping("/health/liveness")
     public String liveness() {

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/agones/AgonesHook.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/agones/AgonesHook.java
@@ -28,6 +28,7 @@ public class AgonesHook {
     @Getter
     private final GameServer currentGameServer;
 
+    @Getter
     private final Agones agones;
 
     public AgonesHook(@Value("${agones.host-port}") int agonesPort) throws ExecutionException, InterruptedException {

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/game/GameLogic.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/game/GameLogic.java
@@ -1,11 +1,6 @@
 package dev.totallyspies.spydle.gameserver.game;
 
-import dev.totallyspies.spydle.gameserver.message.session.SessionOpenEvent;
-import dev.totallyspies.spydle.gameserver.storage.CurrentGameServerConfiguration;
 import dev.totallyspies.spydle.shared.model.ClientSession;
-import dev.totallyspies.spydle.shared.model.GameServer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -24,25 +19,11 @@ public class GameLogic {
     private final AtomicReference<String> currentSubString;
     public static final int TOTAL_GAME_TIME_SECONDS = 30;
 
-    @Autowired
-    public GameServer currentGameServer;
-
-    @Autowired
-    public CurrentGameServerConfiguration currentGameServerConfiguration;
-
     public GameLogic() {
         this.players = new AtomicReference<>(new ArrayList<>());
         this.currentSubString = new AtomicReference<>("");
         this.turn = new AtomicInteger(0);
         this.playerMap = new ConcurrentHashMap<>();
-    }
-
-    @EventListener(SessionOpenEvent.class)
-    public void onSessionOpen() {
-        if (currentGameServer.getState() == GameServer.State.READY) { // This is our first client! Set us to WAITING
-            currentGameServer.setState(GameServer.State.WAITING);
-            currentGameServerConfiguration.updateInStorage();
-        }
     }
 
     public void gameStart(Collection<ClientSession> sessions) {

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/game/GameLogic.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/game/GameLogic.java
@@ -41,6 +41,7 @@ public class GameLogic {
     public void onSessionOpen() {
         if (currentGameServer.getState() == GameServer.State.READY) { // This is our first client! Set us to WAITING
             currentGameServer.setState(GameServer.State.WAITING);
+            currentGameServerConfiguration.updateInStorage();
         }
     }
 

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/game/GameLogic.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/game/GameLogic.java
@@ -1,6 +1,11 @@
 package dev.totallyspies.spydle.gameserver.game;
 
+import dev.totallyspies.spydle.gameserver.message.session.SessionOpenEvent;
+import dev.totallyspies.spydle.gameserver.storage.CurrentGameServerConfiguration;
 import dev.totallyspies.spydle.shared.model.ClientSession;
+import dev.totallyspies.spydle.shared.model.GameServer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -19,11 +24,24 @@ public class GameLogic {
     private final AtomicReference<String> currentSubString;
     public static final int TOTAL_GAME_TIME_SECONDS = 30;
 
+    @Autowired
+    public GameServer currentGameServer;
+
+    @Autowired
+    public CurrentGameServerConfiguration currentGameServerConfiguration;
+
     public GameLogic() {
         this.players = new AtomicReference<>(new ArrayList<>());
         this.currentSubString = new AtomicReference<>("");
         this.turn = new AtomicInteger(0);
         this.playerMap = new ConcurrentHashMap<>();
+    }
+
+    @EventListener(SessionOpenEvent.class)
+    public void onSessionOpen() {
+        if (currentGameServer.getState() == GameServer.State.READY) { // This is our first client! Set us to WAITING
+            currentGameServer.setState(GameServer.State.WAITING);
+        }
     }
 
     public void gameStart(Collection<ClientSession> sessions) {

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/model/ClientSession.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/model/ClientSession.java
@@ -27,4 +27,15 @@ public class ClientSession implements Serializable {
         CONNECTED // Client has connected to this gameserver
     }
 
+    // TODO Investigate later why this is needed
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof ClientSession session)) return false;
+        if (session.getClientId() == null || !session.getClientId().equals(clientId)) return false;
+        if (session.getGameServer() == null || !session.getGameServer().equals(gameServer)) return false;
+        if (session.getPlayerName() == null || !session.getPlayerName().equals(playerName)) return false;
+        if (session.getState() == null || !session.getState().equals(state)) return false;
+        return true;
+    }
+
 }


### PR DESCRIPTION
- On client session close, added a check to see if it was the last player left on the server, and we are not currently in READY state (so PLAYING or WAITING).
  - If passed, shutdown server immediately by sending a signal to agones.

NOTE:
- Added a small bit of logic for setting the server's state to WAITING as soon as it receives a `SocketOpenEvent` (player has successfully connected to us)
- @chopikus <b>you need to write the rest of the logic for updating this state</b>, similar to what I have done.
  - Reminder:
    - READY: No players have connected, this gameserver is just waiting to be assigned players by the matchmaker.
    - WAITING: At least one player has connected, but no one has pressed the "start game" button
    - PLAYING: Players are playing the game and no one can join.
  - Gameservers are only listed in the "room list" on the frontend if they are in WAITING state, and are set to public
  - You need to implement the logic for WAITING -> PLAYING!