### PR TITLE
Created (real) Frontend Local Profile

### DIFF
--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketConfig.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/client/ClientSocketConfig.java
@@ -18,7 +18,7 @@ public class ClientSocketConfig {
     }
 
     @Bean
-    @Profile("!local")
+    @Profile("!test")
     public ClientSocketHandler globalClientSocketHandler() {
         return createClient();
     }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_end/GameEndViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_end/GameEndViewController.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class GameEndViewController {
 
     private final ApplicationEventPublisher publisher;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_end/GameEndViewModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_end/GameEndViewModel.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 @Data
 public class GameEndViewModel {
 

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_room/GameRoomPresenter.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_room/GameRoomPresenter.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class GameRoomPresenter {
 
     private final GameRoomViewModel model;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_room/GameRoomViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_room/GameRoomViewController.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class GameRoomViewController {
 
     private final Logger logger = LoggerFactory.getLogger(GameRoomViewController.class);

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_room/GameRoomViewModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/game_room/GameRoomViewModel.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@Profile("!local")
+@Profile("!test")
 public class GameRoomViewModel {
 
     private List<Player> playerList = new LinkedList<>(); // List of all players in order

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsPresenter.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsPresenter.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class ListRoomsPresenter {
 
     private final ListRoomsView view;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewController.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class ListRoomsViewController {
 
     private final ApplicationEventPublisher publisher;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewController.java
@@ -1,7 +1,7 @@
 package dev.totallyspies.spydle.frontend.interface_adapters.list_rooms;
 
 import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.SwitchViewEvent;
-import dev.totallyspies.spydle.frontend.use_cases.list_games.ListGamesInteractor;
+import dev.totallyspies.spydle.frontend.use_cases.list_games.ListGamesInputBoundary;
 import dev.totallyspies.spydle.frontend.use_cases.list_games.ListGamesOutputData;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Profile;
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Component;
 public class ListRoomsViewController {
 
     private final ApplicationEventPublisher publisher;
-    private final ListGamesInteractor listGamesInteractor;
+    private final ListGamesInputBoundary listGamesInteractor;
 
-    public ListRoomsViewController(ApplicationEventPublisher publisher, ListGamesInteractor listGamesInteractor) {
+    public ListRoomsViewController(ApplicationEventPublisher publisher, ListGamesInputBoundary listGamesInteractor) {
         this.publisher = publisher;
         this.listGamesInteractor = listGamesInteractor;
     }

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/list_rooms/ListRoomsViewModel.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@Profile("!local")
+@Profile("!test")
 public class ListRoomsViewModel {
 
     private String[] linesInRoomList;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ViewManagerModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/view_manager/ViewManagerModel.java
@@ -20,7 +20,7 @@ import java.awt.*;
 Game View, which also acts as the window Frame
  */
 @Component
-@Profile("!local")
+@Profile("!test")
 public class ViewManagerModel extends JFrame {
 
     // Define the CardLayout and panel container

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewController.java
@@ -2,15 +2,15 @@ package dev.totallyspies.spydle.frontend.interface_adapters.welcome;
 
 import dev.totallyspies.spydle.frontend.client.ClientSocketHandler;
 import dev.totallyspies.spydle.frontend.interface_adapters.game_room.GameRoomViewModel;
-import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.SwitchViewEvent;
 import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.ErrorViewEvent;
+import dev.totallyspies.spydle.frontend.interface_adapters.view_manager.SwitchViewEvent;
+import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameInputBoundary;
 import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameInputData;
-import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameInteractor;
 import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameOutputData;
 import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameOutputDataFail;
 import dev.totallyspies.spydle.frontend.use_cases.create_game.CreateGameOutputDataSuccess;
+import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameInputBoundary;
 import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameInputData;
-import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameInteractor;
 import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameOutputData;
 import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameOutputDataFail;
 import dev.totallyspies.spydle.frontend.use_cases.join_game.JoinGameOutputDataSuccess;
@@ -30,16 +30,16 @@ public class WelcomeViewController {
     private final ApplicationEventPublisher publisher;
     private final WelcomeViewModel welcomeModel;
     private final GameRoomViewModel gameRoomModel;
-    private final CreateGameInteractor createGameInteractor;
-    private final JoinGameInteractor joinGameInteractor;
+    private final CreateGameInputBoundary createGameInteractor;
+    private final JoinGameInputBoundary joinGameInteractor;
     private final ClientSocketHandler socketHandler;
 
     public WelcomeViewController(
             ApplicationEventPublisher publisher,
             WelcomeViewModel welcomeModel,
             GameRoomViewModel gameRoomModel,
-            CreateGameInteractor createGameInteractor,
-            JoinGameInteractor joinGameInteractor,
+            CreateGameInputBoundary createGameInteractor,
+            JoinGameInputBoundary joinGameInteractor,
             ClientSocketHandler socketHandler
     ) {
         this.publisher = publisher;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewController.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewController.java
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class WelcomeViewController {
 
     private final Logger logger = LoggerFactory.getLogger(WelcomeViewController.class);

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewModel.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/interface_adapters/welcome/WelcomeViewModel.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@Profile("!local")
+@Profile("!test")
 public class WelcomeViewModel {
 
     private String playerName = "";

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/test/TestClient.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/test/TestClient.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 import java.util.concurrent.Semaphore;
 
 @Component
-@Profile("local")
+@Profile("test")
 public class TestClient {
 
     private final Logger logger = LoggerFactory.getLogger(TestClient.class);

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class CreateGameInteractor implements CreateGameInputBoundary {
 
     private final String gameServerOverwrite;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/CreateGameInteractor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 @Component
-@Profile("!test")
+@Profile("!test & !local")
 public class CreateGameInteractor implements CreateGameInputBoundary {
 
     private final String gameServerOverwrite;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/LocalCreateGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/create_game/LocalCreateGameInteractor.java
@@ -1,0 +1,25 @@
+package dev.totallyspies.spydle.frontend.use_cases.create_game;
+
+import dev.totallyspies.spydle.shared.SharedConstants;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Profile("local")
+public class LocalCreateGameInteractor implements CreateGameInputBoundary {
+
+    @Override
+    public CreateGameOutputData execute(CreateGameInputData data) {
+        UUID clientId = UUID.randomUUID();
+        return new CreateGameOutputDataSuccess(
+                "localhost",
+                7654,
+                clientId,
+                data.getPlayerName(),
+                SharedConstants.LOCAL_SERVER_ROOM_CODE
+        );
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/guess_word/GuessWordInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/guess_word/GuessWordInteractor.java
@@ -5,9 +5,11 @@ import dev.totallyspies.spydle.shared.proto.messages.SbGuess;
 import dev.totallyspies.spydle.shared.proto.messages.SbMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!test")
 public class GuessWordInteractor implements GuessWordInputBoundary {
 
     private final Logger logger = LoggerFactory.getLogger(GuessWordInteractor.class);

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class JoinGameInteractor implements JoinGameInputBoundary {
 
     private final String gameServerOverwrite;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/JoinGameInteractor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 @Component
-@Profile("!test")
+@Profile("!test & !local")
 public class JoinGameInteractor implements JoinGameInputBoundary {
 
     private final String gameServerOverwrite;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/LocalJoinGameInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/join_game/LocalJoinGameInteractor.java
@@ -1,0 +1,25 @@
+package dev.totallyspies.spydle.frontend.use_cases.join_game;
+
+import dev.totallyspies.spydle.shared.SharedConstants;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Profile("local")
+public class LocalJoinGameInteractor implements JoinGameInputBoundary {
+
+    @Override
+    public JoinGameOutputData execute(JoinGameInputData data) {
+        UUID clientId = UUID.randomUUID();
+        return new JoinGameOutputDataSuccess(
+                "localhost",
+                7654,
+                clientId,
+                data.getPlayerName(),
+                SharedConstants.LOCAL_SERVER_ROOM_CODE
+        );
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
@@ -23,7 +23,7 @@ public class ListGamesInteractor implements ListGamesInputBoundary {
         Object response = webClient.getEndpoint("/list-games", ListGamesResponseModel.class);
         if (response instanceof ListGamesResponseModel responseModel) {
             return new ListGamesOutputData(responseModel.getRoomCodes());
-        } else if (response instanceof ClientErrorResponse clientErrorModel) {
+        } else if (response instanceof ClientErrorResponse) {
             return new ListGamesOutputData(new LinkedList<>());
         }
         return new ListGamesOutputData(new LinkedList<>());

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import java.util.LinkedList;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class ListGamesInteractor implements ListGamesInputBoundary {
 
     public final WebClientService webClient;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/ListGamesInteractor.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import java.util.LinkedList;
 
 @Component
-@Profile("!test")
+@Profile("!test & !local")
 public class ListGamesInteractor implements ListGamesInputBoundary {
 
     public final WebClientService webClient;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/LocalListGamesInteractor.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/use_cases/list_games/LocalListGamesInteractor.java
@@ -1,0 +1,25 @@
+package dev.totallyspies.spydle.frontend.use_cases.list_games;
+
+import dev.totallyspies.spydle.shared.SharedConstants;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Component
+@Profile("local")
+public class LocalListGamesInteractor implements ListGamesInputBoundary {
+
+    private final List<String> games = new LinkedList<>();
+
+    public LocalListGamesInteractor() {
+        games.add(SharedConstants.LOCAL_SERVER_ROOM_CODE);
+    }
+
+    @Override
+    public ListGamesOutputData execute() {
+        return new ListGamesOutputData(games);
+    }
+
+}

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/GameEndView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/GameEndView.java
@@ -9,7 +9,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 @org.springframework.stereotype.Component
-@Profile("!local")
+@Profile("!test")
 public class GameEndView extends JPanel {
 
     private final GameEndViewController controller;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/GameRoomView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/GameRoomView.java
@@ -11,7 +11,7 @@ import java.awt.*;
 import java.util.ArrayList;
 
 @Component
-@Profile("!local")
+@Profile("!test")
 public class GameRoomView extends JPanel {
 
     private final GameRoomViewModel model;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/ListRoomsView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/ListRoomsView.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 
 @org.springframework.stereotype.Component
-@Profile("!local")
+@Profile("!test")
 public class ListRoomsView extends JPanel {
 
     private final ListRoomsViewController controller;

--- a/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/WelcomeView.java
+++ b/frontend/src/main/java/dev/totallyspies/spydle/frontend/views/WelcomeView.java
@@ -14,7 +14,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 
 @org.springframework.stereotype.Component
-@Profile("!local")
+@Profile("!test")
 public class WelcomeView extends JPanel {
 
     private final WelcomeViewController controller;

--- a/frontend/src/main/resources/application-test.properties
+++ b/frontend/src/main/resources/application-test.properties
@@ -1,0 +1,2 @@
+server.backend.url=http://localhost
+logging.level.dev.totallyspies.spydle.frontend=DEBUG

--- a/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/storage/CurrentGameServerConfiguration.java
+++ b/gameserver/src/main/java/dev/totallyspies/spydle/gameserver/storage/CurrentGameServerConfiguration.java
@@ -2,6 +2,7 @@ package dev.totallyspies.spydle.gameserver.storage;
 
 import dev.totallyspies.spydle.gameserver.agones.AgonesHook;
 import dev.totallyspies.spydle.shared.RoomCodeUtils;
+import dev.totallyspies.spydle.shared.SharedConstants;
 import dev.totallyspies.spydle.shared.model.GameServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,13 +42,12 @@ public class CurrentGameServerConfiguration {
     @ConditionalOnProperty(name = "agones.enabled", havingValue = "false")
     public GameServer currentLocalGameServer(@Value("${server.port}") int containerPort) {
         logger.info("Agones disabled, loading local current game server info...");
-        String roomCode = RoomCodeUtils.generateRandomCode();
-        String gameServerName = "gameserver-local-" + roomCode;
+        String gameServerName = "gameserver-local";
         return writeCurrentGameServer(GameServer.builder()
                 .address("localhost")
                 .port(containerPort)
                 .name(gameServerName)
-                .roomCode(roomCode)
+                .roomCode(SharedConstants.LOCAL_SERVER_ROOM_CODE)
                 .publicRoom(false)
                 .state(GameServer.State.READY)
                 .build());

--- a/shared/src/main/java/dev/totallyspies/spydle/shared/SharedConstants.java
+++ b/shared/src/main/java/dev/totallyspies/spydle/shared/SharedConstants.java
@@ -9,4 +9,6 @@ public class SharedConstants {
     public static final String STORAGE_REDIS_SESSION_PREFIX = "session:";
     public static final String STORAGE_REDIS_GAME_SERVER_PREFIX = "gameserver:";
 
+    public static final String LOCAL_SERVER_ROOM_CODE = "LOCAL";
+
 }


### PR DESCRIPTION
# Changes
- Renamed old frontend "local" profile to "test"
  - This just loads the test client
- Created a new frontend profile called "local"
  - The goal with this profile is to connect to a local gameserver using the _graphical_ frontend interface, rather than connect to a remote one in the cloud.
  - This one creates alternative beans for our `CreateGameInteractor`, `JoinGameInteractor`, and `ListGamesInteractor` called `LocalCreateGameInteractor`, `LocalJoinGameInteractor` and `LocalListGamesInteractor`
  - Instead of querying a remote server (matchmaker) to get server information, these beans will instead just return connection info for `localhost` on port `7654`.

## Using the Local Profile
- It is suggested you create 5 different duplicate springboot run configurations in your intellij:
  - Frontend local 1
  - Frontend local 2
  - Frontend 1
  - Frontend 2
  - Frontend Test

These should use the obvious profiles (local, dev/prod, test)

- Then for your `GameServer` spring run configuration, set its profile to `local`
- Then create three <b>compound</b> run configurations
  - Double frontend local (runs: frontend local 1, frontend local 2, and also gameserver)
  - Double frontend (runs: frontend local 1, frontend local 2)
  - Frontend Test (runs: Frontend test, gameserver)