### PR TITLE
Added gradle task to create executable jar

### DIFF
--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "3.3.5"
     id("io.spring.dependency-management") version "1.1.6"
+    application
 }
 
 group = "dev.totallyspies.spydle"
@@ -17,6 +18,10 @@ configurations {
     compileOnly {
         extendsFrom(configurations.annotationProcessor.get())
     }
+}
+
+application {
+    mainClass.set("dev.totallyspies.spydle.frontend.FrontendApplication")
 }
 
 repositories {


### PR DESCRIPTION
When you run `gradle :frontend:build`, it will create an executable jar in `Spydle/frontend/build/libs/gameserver.jar`.

Note that you must have java 17 installed on your computer to run this jar.